### PR TITLE
Add metric plotting for training

### DIFF
--- a/ConvNextV2/train_gpu_finetune.py
+++ b/ConvNextV2/train_gpu_finetune.py
@@ -17,6 +17,13 @@ from util.utils import TensorboardLogger, str2bool, remap_checkpoint_keys, load_
 from models import *
 from optim_factory import create_optimizer, LayerDecayValueAssigner
 from estimate_model import Predictor, Plot_ROC, predict_single_image
+from sklearn.metrics import confusion_matrix
+from util.metrics import (
+    plot_confusion_matrix,
+    plot_roc_curve_multiclass,
+    plot_pr_curve_multiclass,
+    calculate_specificity,
+)
 
 
 def get_args_parser():
@@ -443,6 +450,45 @@ def main(args):
     predict_single_image(model_without_ddp, device)
     Predictor(model_without_ddp, data_loader_val, args.resume, device)
     Plot_ROC(model_without_ddp, data_loader_val, args.resume, device)
+
+    # additional metrics using util.metrics
+    all_labels = []
+    all_probs = []
+    model_without_ddp.eval()
+    with torch.no_grad():
+        for images, labels in data_loader_val:
+            images = images.to(device)
+            outputs = model_without_ddp(images)
+            probs = torch.softmax(outputs, dim=1)
+            all_probs.append(probs.cpu().numpy())
+            all_labels.append(labels.numpy())
+
+    all_probs = np.concatenate(all_probs, axis=0)
+    all_labels = np.concatenate(all_labels, axis=0)
+
+    cm = confusion_matrix(all_labels, np.argmax(all_probs, axis=1))
+
+    if os.path.exists('./classes_indices.json'):
+        with open('./classes_indices.json', 'r') as f:
+            class_dict = json.load(f)
+        class_names = [class_dict[str(i)] for i in range(len(class_dict))]
+    else:
+        class_names = [str(i) for i in range(cm.shape[0])]
+
+    if args.output_dir:
+        os.makedirs(args.output_dir, exist_ok=True)
+    fig_cm = plot_confusion_matrix(cm, class_names)
+    fig_cm.savefig(os.path.join(args.output_dir, 'confusion_matrix.png'))
+
+    labels_one_hot = np.eye(len(class_names))[all_labels]
+    fig_roc = plot_roc_curve_multiclass(labels_one_hot, all_probs, class_names)
+    fig_roc.savefig(os.path.join(args.output_dir, 'roc_curve.png'))
+
+    fig_pr = plot_pr_curve_multiclass(labels_one_hot, all_probs, class_names)
+    fig_pr.savefig(os.path.join(args.output_dir, 'pr_curve.png'))
+
+    specificity = calculate_specificity(cm)
+    print(f'Specificity: {specificity:.4f}')
 
 
 if __name__ == '__main__':

--- a/ConvNextV2/util/metrics.py
+++ b/ConvNextV2/util/metrics.py
@@ -1,0 +1,82 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.metrics import roc_curve, auc, precision_recall_curve
+
+
+def plot_confusion_matrix(cm, class_names):
+    """Plot confusion matrix and return the matplotlib Figure."""
+    figure = plt.figure(figsize=(6, 6))
+    plt.imshow(cm, interpolation='nearest', cmap=plt.cm.Blues)
+    plt.title("Confusion Matrix")
+    plt.colorbar()
+    tick_marks = np.arange(len(class_names))
+    plt.xticks(tick_marks, class_names, rotation=45)
+    plt.yticks(tick_marks, class_names)
+
+    thresh = cm.max() / 2.0
+    for i in range(cm.shape[0]):
+        for j in range(cm.shape[1]):
+            plt.text(j, i, format(cm[i, j], 'd'),
+                     horizontalalignment="center",
+                     color="white" if cm[i, j] > thresh else "black")
+
+    plt.tight_layout()
+    plt.ylabel('True label')
+    plt.xlabel('Predicted label')
+    return figure
+
+
+def plot_roc_curve_multiclass(labels_one_hot, preds_prob, class_names):
+    """Plot multi-class ROC curve using one-vs-rest strategy."""
+    num_classes = labels_one_hot.shape[1]
+    plt.figure(figsize=(6, 6))
+
+    for i in range(num_classes):
+        fpr, tpr, _ = roc_curve(labels_one_hot[:, i], preds_prob[:, i])
+        roc_auc = auc(fpr, tpr)
+        plt.plot(fpr, tpr, label=f'{class_names[i]} (AUC = {roc_auc:.2f})')
+
+    plt.plot([0, 1], [0, 1], 'r--')
+    plt.xlim([0.0, 1.0])
+    plt.ylim([0.0, 1.05])
+    plt.xlabel('False Positive Rate')
+    plt.ylabel('True Positive Rate')
+    plt.title('Multi-class ROC')
+    plt.legend(loc="lower right")
+
+    figure = plt.gcf()
+    return figure
+
+
+def plot_pr_curve_multiclass(labels_one_hot, preds_prob, class_names):
+    """Plot multi-class Precision-Recall curve using one-vs-rest strategy."""
+    num_classes = labels_one_hot.shape[1]
+    plt.figure(figsize=(6, 6))
+
+    for i in range(num_classes):
+        precision_vals, recall_vals, _ = precision_recall_curve(labels_one_hot[:, i], preds_prob[:, i])
+        pr_auc = auc(recall_vals, precision_vals)
+        plt.plot(recall_vals, precision_vals, label=f'{class_names[i]} (AUC = {pr_auc:.2f})')
+
+    plt.xlim([0.0, 1.0])
+    plt.ylim([0.0, 1.05])
+    plt.xlabel('Recall')
+    plt.ylabel('Precision')
+    plt.title('Multi-class Precision-Recall')
+    plt.legend(loc="upper right")
+
+    figure = plt.gcf()
+    return figure
+
+
+def calculate_specificity(cm):
+    """Calculate specificity for each class and return the mean."""
+    specificities = []
+    for i in range(cm.shape[0]):
+        tp = cm[i, i]
+        fp = cm[:, i].sum() - tp
+        fn = cm[i, :].sum() - tp
+        tn = cm.sum() - (tp + fp + fn)
+        spec = tn / (tn + fp) if (tn + fp) != 0 else 0
+        specificities.append(spec)
+    return np.mean(specificities)


### PR DESCRIPTION
## Summary
- add utility functions to plot confusion matrix, ROC curve, PR curve and specificity
- call these metrics at the end of the fine-tune script

## Testing
- `python -m py_compile ConvNextV2/util/metrics.py ConvNextV2/train_gpu_finetune.py`

------
https://chatgpt.com/codex/tasks/task_e_684950f07ea88333a731b5173bf77975